### PR TITLE
[WIP] Implement modified REXI for SWE_Plane, now possible to use Gauss

### DIFF
--- a/src/programs/swe_plane/SWE_Plane_TS_l_rexi.cpp
+++ b/src/programs/swe_plane/SWE_Plane_TS_l_rexi.cpp
@@ -521,18 +521,31 @@ void SWE_Plane_TS_l_rexi::run_timestep_real(
 	o_v = Convert_PlaneDataComplex_To_PlaneData::physical_convert(perThreadVars[0]->v_sum);
 
 #else
+        complex gamma0 = 0;
+        for (int i=0; i<max_N; i++) gamma0 -= rexi_beta[i] / rexi_alpha[i];
+        gamma0 += 1;
+        if (1) {
+          // std::cerr << "gamma0 " << gamma0 << std::endl;
+          o_h_pert = gamma0.real() * i_h_pert;
+          o_u = gamma0.real() * o_u;
+          o_v = gamma0.real() * o_v;
+        } else {
+          o_h_pert.spectral_set_zero();
+          o_u.spectral_set_zero();
+          o_v.spectral_set_zero();
+        }
 
 	if (simVars.rexi.use_half_poles)
 	{
-		o_h_pert = Convert_PlaneDataComplex_To_PlaneData::physical_convert(perThreadVars[0]->h_sum);
-		o_u = Convert_PlaneDataComplex_To_PlaneData::physical_convert(perThreadVars[0]->u_sum);
-		o_v = Convert_PlaneDataComplex_To_PlaneData::physical_convert(perThreadVars[0]->v_sum);
+		o_h_pert += Convert_PlaneDataComplex_To_PlaneData::physical_convert(perThreadVars[0]->h_sum);
+		o_u += Convert_PlaneDataComplex_To_PlaneData::physical_convert(perThreadVars[0]->u_sum);
+		o_v += Convert_PlaneDataComplex_To_PlaneData::physical_convert(perThreadVars[0]->v_sum);
 	}
 	else
 	{
-		o_h_pert = Convert_PlaneDataComplex_To_PlaneData::spectral_convert_physical_real_only(perThreadVars[0]->h_sum);
-		o_u = Convert_PlaneDataComplex_To_PlaneData::spectral_convert_physical_real_only(perThreadVars[0]->u_sum);
-		o_v = Convert_PlaneDataComplex_To_PlaneData::spectral_convert_physical_real_only(perThreadVars[0]->v_sum);
+		o_h_pert += Convert_PlaneDataComplex_To_PlaneData::spectral_convert_physical_real_only(perThreadVars[0]->h_sum);
+		o_u += Convert_PlaneDataComplex_To_PlaneData::spectral_convert_physical_real_only(perThreadVars[0]->u_sum);
+		o_v += Convert_PlaneDataComplex_To_PlaneData::spectral_convert_physical_real_only(perThreadVars[0]->v_sum);
 	}
 #endif
 


### PR DESCRIPTION
The modified REXI form is the same as REXI except that the completion
formula depends on the state at the beginning of the step,

    u_{n+1} = gamma0 * u_n + sum beta_i (alpha_i + dt * L)^{-1} u_n

where `gamma0 = 1 - sum beta_i/alpha_i`.  Classic REXI has `gamma0 = 0`.

* This PR is incomplete: This capability should probably go everywhere, or at least have a plan for how to put it everywhere.

* Coefficient files can be generated using `rkanalysis.py` (from our `rk-rexi` repo):
```
    python -c 'import rkanalysis as rk; rk._write_rexi(*rk.butcher2rexi(*rk.gauss(8)[:2]))'
```
and run using the options
`--rexi-method=file --rexi-file-alpha=rexi_alpha.csv --rexi-file-beta=rexi_beta_re.csv`