### PR TITLE
Add EL-REXI Bean-REXI and LR-REXI to rexi_benchmarks.py

### DIFF
--- a/benchmarks_sphere/report_konwihr_rexi_nl/compare_wt_dt_vs_accuracy_galewsky/rexi_benchmarks.py
+++ b/benchmarks_sphere/report_konwihr_rexi_nl/compare_wt_dt_vs_accuracy_galewsky/rexi_benchmarks.py
@@ -135,14 +135,14 @@ def get_rexi_benchmarks(jg):
             # "phi0"
             pcirexi = PCIREXI()
             contour = RectangleContour(23, 2 * max_imag + 20, -1)
-            i_s = InterpolationSettings(4, 2, 'equidistant')
+            i_s = InterpolationSettings(4, 2, 'equidistant', False, False)
             q_s = QuadratureSettings(overall_quadrature_points=128,
                                      quadrature_method="legendre",
                                      distribute_quad_points_based_on_arc_length=True)
             coeffs_phi0 = pcirexi.setup_pcirexi(contour=contour,
                                                 interpolation_settings=i_s,
                                                 quadrature_settings=q_s)
-            coeffs_phi0.unique_id = "LR_REXI(width=23, height=" + str(2 * max_imag + 20) + ", center=-1, terms=128)"
+            coeffs_phi0.unique_id_string = "LR_REXI(width=23, height=" + str(2 * max_imag + 20) + ", center=-1, terms=128)"
             rexi_method['rexi_files_coefficients'] = [coeffs_phi0]
 
             # Add to list of REXI methods
@@ -165,13 +165,13 @@ def get_rexi_benchmarks(jg):
             # "phi0"
             pcirexi = PCIREXI()
             contour = BeanContour(16, max_imag / 30 * 35, -2)
-            i_s = InterpolationSettings(1, 0, 'direct')
+            i_s = InterpolationSettings(1, 0, 'direct', False, False)
             q_s = QuadratureSettings(overall_quadrature_points=max(64, int(75 * max_imag / 30)),
-                                     quadrature_method="midpoint")
+                                     quadrature_method="midpoint", distribute_quad_points_based_on_arc_length=False)
             coeffs_phi0 = pcirexi.setup_pcirexi(contour=contour,
                                                 interpolation_settings=i_s,
                                                 quadrature_settings=q_s)
-            coeffs_phi0.unique_id = "Bean_REXI(width=16, height=" + str(
+            coeffs_phi0.unique_id_string = "Bean_REXI(width=16, height=" + str(
                 max_imag / 30 * 35) + ", center=-2, terms=" + str(max(64, int(75 * max_imag / 30))) + ")"
             rexi_method['rexi_files_coefficients'] = [coeffs_phi0]
 

--- a/benchmarks_sphere/report_konwihr_rexi_nl/compare_wt_dt_vs_accuracy_galewsky/rexi_benchmarks.py
+++ b/benchmarks_sphere/report_konwihr_rexi_nl/compare_wt_dt_vs_accuracy_galewsky/rexi_benchmarks.py
@@ -8,22 +8,23 @@ from itertools import product
 
 # REXI
 from mule_local.rexi.REXICoefficients import *
+from mule_local.rexi.pcirexi.contour.BeanContour import BeanContour
+from mule_local.rexi.pcirexi.contour.RectangleContour import RectangleContour
 from mule_local.rexi.trexi.TREXI import *
 from mule_local.rexi.cirexi.CIREXI import *
+from mule_local.rexi.elrexi.ELREXI import *
 from mule_local.rexi.brexi.BREXI import *
+from mule_local.rexi.pcirexi.PCIREXI import *
 
 # EFloat
 efloat_mode = "float"
 
 
-
 def get_rexi_benchmarks(jg):
-
     # Accumulator of all REXI methods
     # rexi_method['rexi_method'] = 'file'               # Choose REXI method which is typically 'file' for all file-based ones
     # rexi_method['rexi_files_coefficients'] = None     # List with approximations for different 'phi' functions
     rexi_methods = []
-
 
     #
     # CI REXI
@@ -46,12 +47,11 @@ def get_rexi_benchmarks(jg):
         # Yes, that's ugly, but simply how it goes :-)
         #
         params_ci_max_imag_scaling_relative_to_timestep_size = 480
-        #params_ci_max_imag_scaling_relative_to_timestep_size = None
+        # params_ci_max_imag_scaling_relative_to_timestep_size = None
 
         params_ci_min_imag = 5.0
 
         rexi_method = {}
-
 
         # Choose REXI method which is typically 'file' for all file-based ones
         rexi_method['rexi_method'] = 'file'
@@ -59,31 +59,127 @@ def get_rexi_benchmarks(jg):
         # List with approximations for different 'phi' functions
         rexi_method['rexi_files_coefficients'] = None
 
-
         for ci_max_imag, ci_max_real in product(params_ci_max_imag, params_ci_max_real):
 
             if params_ci_max_imag_scaling_relative_to_timestep_size != None:
-                ci_max_imag *= (jg.runtime.timestep_size/params_ci_max_imag_scaling_relative_to_timestep_size)
+                ci_max_imag *= (jg.runtime.timestep_size / params_ci_max_imag_scaling_relative_to_timestep_size)
 
             # "phi0"
-            cirexi = CIREXI(efloat_mode = efloat_mode)
-            coeffs_phi0 = cirexi.setup(function_name="phi0", N=fun_params_ci_N(ci_max_real, ci_max_imag), lambda_include_imag=ci_max_imag, lambda_max_real=ci_max_real).toFloat()
+            cirexi = CIREXI(efloat_mode=efloat_mode)
+            coeffs_phi0 = cirexi.setup(function_name="phi0", N=fun_params_ci_N(ci_max_real, ci_max_imag),
+                                       lambda_include_imag=ci_max_imag, lambda_max_real=ci_max_real).toFloat()
 
             # "phi1"
-            cirexi = CIREXI(efloat_mode = efloat_mode)
-            coeffs_phi1 = cirexi.setup(function_name="phi1", N=fun_params_ci_N(ci_max_real, ci_max_imag), lambda_include_imag=ci_max_imag, lambda_max_real=ci_max_real).toFloat()
+            cirexi = CIREXI(efloat_mode=efloat_mode)
+            coeffs_phi1 = cirexi.setup(function_name="phi1", N=fun_params_ci_N(ci_max_real, ci_max_imag),
+                                       lambda_include_imag=ci_max_imag, lambda_max_real=ci_max_real).toFloat()
 
             # "phi2"
-            cirexi = CIREXI(efloat_mode = efloat_mode)
-            coeffs_phi2 = cirexi.setup(function_name="phi2", N=fun_params_ci_N(ci_max_real, ci_max_imag), lambda_include_imag=ci_max_imag, lambda_max_real=ci_max_real).toFloat()
+            cirexi = CIREXI(efloat_mode=efloat_mode)
+            coeffs_phi2 = cirexi.setup(function_name="phi2", N=fun_params_ci_N(ci_max_real, ci_max_imag),
+                                       lambda_include_imag=ci_max_imag, lambda_max_real=ci_max_real).toFloat()
 
             rexi_method['rexi_files_coefficients'] = [coeffs_phi0, coeffs_phi1, coeffs_phi2]
 
             # Add to list of REXI methods
             rexi_methods.append(rexi_method)
 
+    #
+    # EL-REXI
+    #
+    if True:
+        max_imags = [30.0]
+        rexi_method = {}
+
+        # Choose REXI method which is typically 'file' for all file-based ones
+        rexi_method['rexi_method'] = 'file'
+
+        # List with approximations for different 'phi' functions
+        rexi_method['rexi_files_coefficients'] = None
+
+        for max_imag in max_imags:
+            # "phi0"
+            elrexi = ELREXI(efloat_mode=efloat_mode)
+            coeffs_phi0 = elrexi.setup(function_name="phi0", N=max(64, int(75 * max_imag / 30)), lambda_max_real=10.5,
+                                       lambda_max_imag=max_imag + 2.5).toFloat()
+
+            # "phi1"
+            elrexi = ELREXI(efloat_mode=efloat_mode)
+            coeffs_phi1 = elrexi.setup(function_name="phi1", N=max(64, int(75 * max_imag / 30)), lambda_max_real=10.5,
+                                       lambda_max_imag=max_imag + 2.5).toFloat()
+
+            # "phi2"
+            elrexi = ELREXI(efloat_mode=efloat_mode)
+            coeffs_phi2 = elrexi.setup(function_name="phi2", N=max(64, int(75 * max_imag / 30)), lambda_max_real=10.5,
+                                       lambda_max_imag=max_imag + 2.5).toFloat()
+
+            rexi_method['rexi_files_coefficients'] = [coeffs_phi0, coeffs_phi1, coeffs_phi2]
+
+            # Add to list of REXI methods
+            rexi_methods.append(rexi_method)
+
+    #
+    # LR-REXI (Rectangle contour with Gauss-Legendre Quadrature)
+    #
+    if True:
+        max_imags = [30.0]
+        rexi_method = {}
+
+        # Choose REXI method which is typically 'file' for all file-based ones
+        rexi_method['rexi_method'] = 'file'
+
+        # List with approximations for different 'phi' functions
+        rexi_method['rexi_files_coefficients'] = None
+
+        for max_imag in max_imags:
+            # "phi0"
+            pcirexi = PCIREXI()
+            contour = RectangleContour(23, 2 * max_imag + 20, -1)
+            i_s = InterpolationSettings(4, 2, 'equidistant')
+            q_s = QuadratureSettings(overall_quadrature_points=128,
+                                     quadrature_method="legendre",
+                                     distribute_quad_points_based_on_arc_length=True)
+            coeffs_phi0 = pcirexi.setup_pcirexi(contour=contour,
+                                                interpolation_settings=i_s,
+                                                quadrature_settings=q_s)
+            coeffs_phi0.unique_id = "LR_REXI(width=23, height=" + str(2 * max_imag + 20) + ", center=-1, terms=128"
+            rexi_method['rexi_files_coefficients'] = [coeffs_phi0]
+
+            # Add to list of REXI methods
+            rexi_methods.append(rexi_method)
+
+    #
+    # Bean-REXI
+    #
+    if True:
+        max_imags = [30.0]
+        rexi_method = {}
+
+        # Choose REXI method which is typically 'file' for all file-based ones
+        rexi_method['rexi_method'] = 'file'
+
+        # List with approximations for different 'phi' functions
+        rexi_method['rexi_files_coefficients'] = None
+
+        for max_imag in max_imags:
+            # "phi0"
+            pcirexi = PCIREXI()
+            contour = BeanContour(16, max_imag / 30 * 35, -2)
+            i_s = InterpolationSettings(1, 0, 'direct')
+            q_s = QuadratureSettings(overall_quadrature_points=max(64, int(75 * max_imag / 30)),
+                                     quadrature_method="midpoint")
+            coeffs_phi0 = pcirexi.setup_pcirexi(contour=contour,
+                                                interpolation_settings=i_s,
+                                                quadrature_settings=q_s)
+            coeffs_phi0.unique_id = "Bean_REXI(width=16, height=" + str(
+                max_imag / 30 * 35) + ", center=-2, terms=" + str(max(64, int(75 * max_imag / 30)))
+            rexi_method['rexi_files_coefficients'] = [coeffs_phi0]
+
+            # Add to list of REXI methods
+            rexi_methods.append(rexi_method)
 
     return rexi_methods
+
 
 if __name__ == "__main__":
     pass

--- a/benchmarks_sphere/report_konwihr_rexi_nl/compare_wt_dt_vs_accuracy_galewsky/rexi_benchmarks.py
+++ b/benchmarks_sphere/report_konwihr_rexi_nl/compare_wt_dt_vs_accuracy_galewsky/rexi_benchmarks.py
@@ -142,7 +142,7 @@ def get_rexi_benchmarks(jg):
             coeffs_phi0 = pcirexi.setup_pcirexi(contour=contour,
                                                 interpolation_settings=i_s,
                                                 quadrature_settings=q_s)
-            coeffs_phi0.unique_id = "LR_REXI(width=23, height=" + str(2 * max_imag + 20) + ", center=-1, terms=128"
+            coeffs_phi0.unique_id = "LR_REXI(width=23, height=" + str(2 * max_imag + 20) + ", center=-1, terms=128)"
             rexi_method['rexi_files_coefficients'] = [coeffs_phi0]
 
             # Add to list of REXI methods
@@ -172,7 +172,7 @@ def get_rexi_benchmarks(jg):
                                                 interpolation_settings=i_s,
                                                 quadrature_settings=q_s)
             coeffs_phi0.unique_id = "Bean_REXI(width=16, height=" + str(
-                max_imag / 30 * 35) + ", center=-2, terms=" + str(max(64, int(75 * max_imag / 30)))
+                max_imag / 30 * 35) + ", center=-2, terms=" + str(max(64, int(75 * max_imag / 30))) + ")"
             rexi_method['rexi_files_coefficients'] = [coeffs_phi0]
 
             # Add to list of REXI methods

--- a/benchmarks_sphere/report_konwihr_rexi_nl/compare_wt_dt_vs_accuracy_galewsky/rexi_benchmarks.py
+++ b/benchmarks_sphere/report_konwihr_rexi_nl/compare_wt_dt_vs_accuracy_galewsky/rexi_benchmarks.py
@@ -8,13 +8,12 @@ from itertools import product
 
 # REXI
 from mule_local.rexi.REXICoefficients import *
-from mule_local.rexi.pcirexi.contour.BeanContour import BeanContour
-from mule_local.rexi.pcirexi.contour.RectangleContour import RectangleContour
+from mule_local.rexi.pcirexi.BeanREXI import BeanREXI
+from mule_local.rexi.pcirexi.LRREXI import LRREXI
 from mule_local.rexi.trexi.TREXI import *
 from mule_local.rexi.cirexi.CIREXI import *
 from mule_local.rexi.elrexi.ELREXI import *
 from mule_local.rexi.brexi.BREXI import *
-from mule_local.rexi.pcirexi.PCIREXI import *
 
 # EFloat
 efloat_mode = "float"
@@ -133,16 +132,8 @@ def get_rexi_benchmarks(jg):
 
         for max_imag in max_imags:
             # "phi0"
-            pcirexi = PCIREXI()
-            contour = RectangleContour(23, 2 * max_imag + 20, -1)
-            i_s = InterpolationSettings(4, 2, 'equidistant', False, False)
-            q_s = QuadratureSettings(overall_quadrature_points=128,
-                                     quadrature_method="legendre",
-                                     distribute_quad_points_based_on_arc_length=True)
-            coeffs_phi0 = pcirexi.setup_pcirexi(contour=contour,
-                                                interpolation_settings=i_s,
-                                                quadrature_settings=q_s)
-            coeffs_phi0.unique_id_string = "LR_REXI(width=23, height=" + str(2 * max_imag + 20) + ", center=-1, terms=128)"
+            lrrexi = LRREXI()
+            coeffs_phi0 = lrrexi.setup(23, 2 * max_imag + 20, -1, 128)
             rexi_method['rexi_files_coefficients'] = [coeffs_phi0]
 
             # Add to list of REXI methods
@@ -163,16 +154,10 @@ def get_rexi_benchmarks(jg):
 
         for max_imag in max_imags:
             # "phi0"
-            pcirexi = PCIREXI()
-            contour = BeanContour(16, max_imag / 30 * 35, -2)
-            i_s = InterpolationSettings(1, 0, 'direct', False, False)
-            q_s = QuadratureSettings(overall_quadrature_points=max(64, int(75 * max_imag / 30)),
-                                     quadrature_method="midpoint", distribute_quad_points_based_on_arc_length=False)
-            coeffs_phi0 = pcirexi.setup_pcirexi(contour=contour,
-                                                interpolation_settings=i_s,
-                                                quadrature_settings=q_s)
-            coeffs_phi0.unique_id_string = "Bean_REXI(width=16, height=" + str(
-                max_imag / 30 * 35) + ", center=-2, terms=" + str(max(64, int(75 * max_imag / 30))) + ")"
+            beanrexi = BeanREXI()
+
+            coeffs_phi0 = beanrexi.setup(16, max_imag / 30 * 35, -2, max(64, int(75 * max_imag / 30)))
+
             rexi_method['rexi_files_coefficients'] = [coeffs_phi0]
 
             # Add to list of REXI methods

--- a/mule_local/python/mule_local/rexi/pcirexi/BeanREXI.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/BeanREXI.py
@@ -1,0 +1,33 @@
+#! /usr/bin/env python3
+#
+# Author: Raphael Schilling <raphael.schilling@tum.de>
+#
+
+from mule_local.rexi.pcirexi.PCIREXI import PCIREXI
+from mule_local.rexi.pcirexi.contour.BeanContour import BeanContour
+from mule_local.rexi.pcirexi.contour.RectangleContour import RectangleContour
+from mule_local.rexi.pcirexi.section.InterpolationSettings import InterpolationSettings
+from mule_local.rexi.pcirexi.section.QuadratureSettings import QuadratureSettings
+
+
+class BeanREXI:
+    def setup(self, horizontal_radius:float, vertical_radius:float, center:complex, N):
+        pcirexi = PCIREXI()
+        contour = BeanContour(horizontal_radius, vertical_radius, center, compression=0.25)
+        i_s = InterpolationSettings(1, 0, 'direct', False, False)
+        q_s = QuadratureSettings(overall_quadrature_points=N,
+                                 quadrature_method="midpoint",
+                                 distribute_quad_points_based_on_arc_length=False)
+        coeffs = pcirexi.setup_pcirexi(contour=contour,
+                                            interpolation_settings=i_s,
+                                            quadrature_settings=q_s)
+
+        unique_id_string = "BeanREXI_"
+        unique_id_string += "phi0" #self.function_name
+        unique_id_string += "_N" + str(N)
+        unique_id_string += "_hr" + str(horizontal_radius)
+        unique_id_string += "_vr" + str(vertical_radius)
+        unique_id_string += "_c" + str(center)
+
+        coeffs.unique_id_string = unique_id_string
+        return coeffs

--- a/mule_local/python/mule_local/rexi/pcirexi/LRREXI.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/LRREXI.py
@@ -1,0 +1,32 @@
+#! /usr/bin/env python3
+#
+# Author: Raphael Schilling <raphael.schilling@tum.de>
+#
+
+from mule_local.rexi.pcirexi.PCIREXI import PCIREXI
+from mule_local.rexi.pcirexi.contour.RectangleContour import RectangleContour
+from mule_local.rexi.pcirexi.section.InterpolationSettings import InterpolationSettings
+from mule_local.rexi.pcirexi.section.QuadratureSettings import QuadratureSettings
+
+
+class LRREXI:
+    def setup(self, width:float, height:float, center:complex, N:int):
+        pcirexi = PCIREXI()
+        contour = RectangleContour(width, height, center)
+        i_s = InterpolationSettings(4, 2, 'equidistant', False, False)
+        q_s = QuadratureSettings(overall_quadrature_points=N,
+                                 quadrature_method="legendre",
+                                 distribute_quad_points_based_on_arc_length=True)
+        coeffs = pcirexi.setup_pcirexi(contour=contour,
+                                            interpolation_settings=i_s,
+                                            quadrature_settings=q_s)
+
+        unique_id_string = "LRREXI_"
+        unique_id_string += "phi0" #self.function_name
+        unique_id_string += "_N" + str(N)
+        unique_id_string += "_w" + str(width)
+        unique_id_string += "_h" + str(height)
+        unique_id_string += "_c" + str(center)
+
+        coeffs.unique_id_string = unique_id_string
+        return coeffs

--- a/mule_local/python/mule_local/rexi/pcirexi/PCIREXI.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/PCIREXI.py
@@ -1,0 +1,84 @@
+#! /usr/bin/env python3
+#
+# Author: Raphael Schilling <raphael.schilling@tum.de>
+#
+import cmath
+
+from mule_local.rexi.REXICoefficients import REXICoefficients
+from mule_local.rexi.pcirexi.cauchy_integrator import CauchyIntegrator
+from mule_local.rexi.pcirexi.contour.Contour import Contour
+from mule_local.rexi.pcirexi.section.InterpolationSettings import InterpolationSettings
+from mule_local.rexi.pcirexi.section.QuadratureSettings import QuadratureSettings
+from mule_local.rexi.pcirexi.section.section_factory import SectionFactory
+
+
+class PCIREXI:
+    contour: Contour = None
+    interpolation_settings: InterpolationSettings = None
+    quadrature_settings: QuadratureSettings = None
+
+    #
+    # Constructor
+    # See setup(...) for documentation on parameters
+    # 
+    def __init__(
+            self
+    ):
+
+        self.alphas = []
+        self.betas = []
+        self.unique_id_string = ""
+        self.section_factory = SectionFactory()
+        self.section_list = []
+
+    def setup_pcirexi(self, contour: Contour, interpolation_settings: InterpolationSettings,
+                      quadrature_settings: QuadratureSettings):
+        if self.contour is None or self.interpolation_settings is None or self.contour != contour or \
+                self.interpolation_settings != interpolation_settings:
+            self.contour = contour
+            self.interpolation_settings = interpolation_settings
+            self.section_list = self.create_sections()
+
+        self.quadrature_settings = quadrature_settings
+        return self._setup_quadrature(quadrature_settings)
+
+    def _setup_quadrature(self, quadrature_settings: QuadratureSettings):
+        self.create_coefficients()
+        coeffs = REXICoefficients()
+        coeffs.alphas = [a for a in self.alphas[:]]
+        coeffs.betas = [b for b in self.betas[:]]
+        coeffs.alphas.reverse()
+        coeffs.betas.reverse()
+        #TODO: Wirred hack to get the same oredring as EL-REXI
+        coeffs.alphas = coeffs.alphas[len(coeffs.alphas)*3//4:]+coeffs.alphas[0:len(coeffs.alphas)*3//4]
+        coeffs.betas = coeffs.betas[len(coeffs.alphas)*3//4:]+coeffs.betas[0:len(coeffs.alphas)*3//4]
+        coeffs.gamma = 0
+        coeffs.unique_id_string = self.getUniqueId()
+        coeffs.function_name = "phi0"
+        return coeffs
+
+    def getUniqueId(self):
+        return "PCIREXI_" + self.unique_id_string
+
+    def create_sections(self):
+        if self.interpolation_settings.interp_method.startswith("direct"):
+            return self.contour.single_section_list()
+
+        return self.section_factory.generate_sections(self.contour.f,
+                                                      self.contour.f_derivative,
+                                                      self.interpolation_settings.section_number, \
+                                                      self.interpolation_settings.interp_per_section,
+                                                      self.interpolation_settings.interp_method, \
+                                                      equilong=self.interpolation_settings.same_arc_length_for_all_sections,
+                                                      sample_points_arc_length_positioned=
+                                                                 self.interpolation_settings.sample_nodes_based_on_arc_length)
+
+    def create_coefficients(self):
+        # TODO: cmath.exp ist noch explizit
+        cauchy_integrator = CauchyIntegrator(self.section_list, cmath.exp, \
+                                             self.quadrature_settings.overall_quadrature_points,
+                                             self.quadrature_settings.quadrature_method,
+                                             arc_length_distribution=self.quadrature_settings.
+                                             distribute_quad_points_based_on_arc_length)
+        self.alphas = cauchy_integrator.a_s[:]
+        self.betas = cauchy_integrator.bs[:]

--- a/mule_local/python/mule_local/rexi/pcirexi/cauchy_integrator.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/cauchy_integrator.py
@@ -50,7 +50,6 @@ class CauchyIntegrator:
                 print("Ig: lobatto")
                 base_nodes, weights_original = g_c.gauss_lobatto(terms_number, 20)
             elif integral.startswith('legendre'):
-                print("Ig: legendre")
                 base_nodes, weights_original = g_c.gauss_legendre(terms_number, 20)
             elif integral.startswith('chebychev'):
                 raise
@@ -60,7 +59,6 @@ class CauchyIntegrator:
             weights = [float(w) / 2 for w in weights_original]
             base_nodes = [float(b) / 2 + 0.5 for b in base_nodes]
         elif integral.startswith('trapeze'):
-            print("Ig: trapeze")
             if terms_number == 0:
                 base_nodes = []
                 weights = []
@@ -72,7 +70,6 @@ class CauchyIntegrator:
                     devisor = (2 * (terms_number - 1))
                     weights = [1 / devisor] + [2 / devisor] * (terms_number - 2) + [1 / devisor]
         elif integral.startswith('midpoint'):
-            print("Ig: midpoint")
             if terms_number == 0:
                 base_nodes = []
                 weights = []
@@ -189,4 +186,3 @@ class CauchyIntegrator:
                     max_i_so_far = i
                     max_value = current_length
             self.terms_section_list[max_i_so_far] += 1
-        print(self.terms_section_list)

--- a/mule_local/python/mule_local/rexi/pcirexi/cauchy_integrator.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/cauchy_integrator.py
@@ -1,0 +1,192 @@
+from functools import reduce, lru_cache
+import numpy as np
+from typing import List, Any, Callable
+import scipy.integrate as integrate
+
+from mule_local.rexi.pcirexi.gauss_cache import GaussCache
+from mule_local.rexi.pcirexi.section import section
+
+
+def _complex_quad(func, a, b):
+    real = integrate.quad((lambda a: func(a).real), a, b)[0]
+    imag = integrate.quad((lambda a: func(a).imag), a, b)[0]
+    return real + 1j * imag
+
+class CauchyIntegrator:
+    target_function: Callable[[Any], Any]  # exp for REXI
+    bs: List[complex]  # numerator of terms
+    a_s: List[complex]  # part of the denominator
+    terms_number: int  # overall number of REXI terms
+    terms_section_list: int  # REXI terms per section
+    sections: List[section.Section]  # list of contour functions
+
+    def __init__(self, sections, target_function, terms_number=20, integral='trapeze', arc_length_distribution=False,
+                 normalize_for_zero=False, g_c=GaussCache()):
+        self.g_c = g_c
+        self.target_function = target_function
+        self.sections = sections
+        self.terms_number = terms_number
+        self.integral = integral
+        self._calculate_quad_points_for_sections(arc_length_distribution)
+        if integral.startswith("trapeze") or integral.startswith("lobatto"):
+            self.edge_to_edge = True
+            # Temporarly increase terms. Later undone by merging values from bs and a_s
+            self.terms_section_list = [t + 1 for t in self.terms_section_list]
+        else:
+            self.edge_to_edge = False
+        self._calculateTable()
+        if normalize_for_zero:
+            self._normalize_for_zero()
+
+    @lru_cache(maxsize=32)
+    def get_quadrature_points_and_weights(self, g_c, integral, terms_number):
+        # if terms_number % self.terms_per_section != 0:
+        #    print("#terms is not dividable by operations_per_section")
+        if (not integral.startswith('trapeze')) and (not integral.startswith('midpoint')):
+            if integral.startswith('lobatto'):
+                if terms_number < 2:
+                    print("Lobatto needs at least 2 base_nodes")
+                    raise
+                print("Ig: lobatto")
+                base_nodes, weights_original = g_c.gauss_lobatto(terms_number, 20)
+            elif integral.startswith('legendre'):
+                print("Ig: legendre")
+                base_nodes, weights_original = g_c.gauss_legendre(terms_number, 20)
+            elif integral.startswith('chebychev'):
+                raise
+            else:
+                print("Unknown Interation")
+                raise
+            weights = [float(w) / 2 for w in weights_original]
+            base_nodes = [float(b) / 2 + 0.5 for b in base_nodes]
+        elif integral.startswith('trapeze'):
+            print("Ig: trapeze")
+            if terms_number == 0:
+                base_nodes = []
+                weights = []
+            else:
+                base_nodes = np.linspace(0, 1, terms_number)
+                if terms_number <= 2:
+                    weights = [1 / terms_number] * terms_number
+                else:
+                    devisor = (2 * (terms_number - 1))
+                    weights = [1 / devisor] + [2 / devisor] * (terms_number - 2) + [1 / devisor]
+        elif integral.startswith('midpoint'):
+            print("Ig: midpoint")
+            if terms_number == 0:
+                base_nodes = []
+                weights = []
+            else:
+                base_nodes = np.linspace(1 / (2 * terms_number), 1 - 1 / (2 * terms_number),
+                                         terms_number)
+                weights = [1 / (terms_number)] * terms_number
+
+        else:
+            raise
+        return (base_nodes, weights)
+
+    def _calculateTable(self):
+        # calculates numerator (bs) and denominator addend (as)
+        self.bs = []
+        self.a_s = []
+        for j in range(len(self.sections)):
+            current_section = self.sections[j]
+            terms = self.terms_section_list[j]
+            base_nodes, weights = self.get_quadrature_points_and_weights(self.g_c, self.integral, terms)
+            for i in range(terms):
+                # prepare one REXI term
+                alpha_for_current_term = base_nodes[i]
+                contour_pos = current_section.interpolate(alpha_for_current_term)
+                contour_derivative = current_section.evaluateDerivative(alpha_for_current_term)
+                function_evaluation_at_contour_pos = self.target_function(contour_pos)
+                b = -1 / (2j * np.pi) * function_evaluation_at_contour_pos * contour_derivative * weights[i]
+                self.bs.append(b)
+                self.a_s.append(-contour_pos)
+        if self.edge_to_edge:
+            # Undo temporary increase of terms
+            current_transition = 0
+            for i in range(len(self.sections)):
+                # Merge values at equal contour position
+                self.bs[current_transition] += self.bs[current_transition - 1]
+                self.a_s[current_transition] = self.a_s[current_transition] / 2 + self.a_s[current_transition - 1] / 2
+                current_transition += self.terms_section_list[i]
+            current_unwanted = 0
+            for i in range(len(self.sections)):
+                # Pop unwanted values
+                current_unwanted += self.terms_section_list[i] - 1
+                self.bs.pop(current_unwanted)
+                self.a_s.pop(current_unwanted)
+
+    def _normalize_for_zero(self):
+        current = self.approximate_target_function(0)
+        actual = self.target_function(0)
+        factor = actual.real / current.real
+        self.bs = [b * factor for b in self.bs]
+
+    def approximate_target_function(self, x):
+        sum: complex = 0j
+        for s in range(0, len(self.bs)):
+            sum += self.bs[s] / (self.a_s[s] + x)
+        return sum
+
+    def approximate_target_function_using_scipy_quad(self, x):
+        sections_sum = 0j
+        for current_section in self.sections:
+            def cauchy_integrand(alpha):
+                contour_pos = current_section.interpolate(alpha)
+                contour_derivative = current_section.evaluateDerivative(alpha)
+                return self.target_function(contour_pos) * contour_derivative / (contour_pos - x)
+
+            sections_sum += _complex_quad(cauchy_integrand, 0, 1)
+        return sections_sum / (2j * np.pi)
+
+    def _get_section(self, a):
+        jump_size = len(self.sections) // 2
+        current_pos = jump_size
+        jump_size //= 2
+        if jump_size == 0:
+            jump_size = 1
+        while True:
+            if a < self.sections[current_pos].start_a:
+                current_pos -= jump_size
+            elif current_pos == len(self.sections) - 1 or a < self.sections[current_pos].end_a:
+                return current_pos
+            else:
+                current_pos += jump_size
+            jump_size //= 2
+            if jump_size == 0:
+                jump_size = 1
+
+    def calc_max_error_in_interval(self, lower_i=-8, higher_i=8, samples=1000):
+        values = np.linspace(lower_i * 1j, higher_i * 1j, samples)
+        deviations = [abs(self.target_function(a) - self.approximate_target_function(a)) for a in values]
+        max_deviation = max(deviations)
+        return max_deviation
+
+    def calc_max_error_in_intervall_via_scipy_quad(self, lower_i=-8, higher_i=8, samples=1000):
+        values = np.linspace(lower_i * 1j, higher_i * 1j, samples)
+        deviations = [abs(self.target_function(a) - self.approximate_target_function_using_scipy_quad(a)) for a in
+                      values]
+        max_deviation = max(deviations)
+        return max_deviation
+
+    def _calculate_quad_points_for_sections(self, arc_length_distribution):
+        if not arc_length_distribution:
+            self.terms_section_list = [self.terms_number // len(self.sections)] * len(self.sections)
+            return
+        self.terms_section_list = [0] * len(self.sections)
+        section_lengths = [s.arc_length_start_end(0, 1) for s in self.sections]
+        contour_length = reduce(float.__add__, section_lengths, 0.0)
+        length_per_quad_point = contour_length / self.terms_number
+        self.terms_section_list = [int(l / length_per_quad_point) for l in section_lengths]
+        current_terms = reduce(int.__add__, self.terms_section_list, 0)
+        for _ in range(0, self.terms_number - current_terms):
+            max_value = -1
+            max_i_so_far = 0
+            for i in range(0, len(section_lengths)):
+                current_length = section_lengths[i] - self.terms_section_list[i] * length_per_quad_point
+                if max_value < current_length:
+                    max_i_so_far = i
+                    max_value = current_length
+            self.terms_section_list[max_i_so_far] += 1
+        print(self.terms_section_list)

--- a/mule_local/python/mule_local/rexi/pcirexi/contour/BeanContour.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/contour/BeanContour.py
@@ -1,0 +1,23 @@
+import math
+
+from mule_local.rexi.pcirexi.contour.Contour import Contour
+
+
+class BeanContour(Contour):
+
+    def __init__(self, horizontal_radius: float, vertical_radius: float, center: float, compression=0.25):
+        self.compression = compression
+        self.center = center
+        self.vertical_radius = vertical_radius
+        self.horizontal_radius = horizontal_radius
+
+    # f: [0, 2pi]->complex
+    def f(self, alpha: float) -> complex:
+        return 1j * math.sin(alpha) * self.vertical_radius + math.cos(alpha) * (
+                1 - math.pow(math.cos(alpha), 3) * self.compression) * self.horizontal_radius + self.center
+
+    # f_derivative: [0, 2pi]->complex
+    def f_derivative(self, alpha: float) -> complex:
+        return 4 * self.horizontal_radius * self.compression * math.sin(alpha) * math.pow(math.cos(alpha),
+                                                                                          3) + 1j * self.vertical_radius * math.cos(
+            alpha) - self.horizontal_radius * math.sin(alpha)

--- a/mule_local/python/mule_local/rexi/pcirexi/contour/Contour.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/contour/Contour.py
@@ -1,0 +1,28 @@
+# interface for contours,
+# can be interpolated
+# or converted into a single section using ????TODO
+import math
+
+from ..section.section import Section
+
+
+class Contour:
+    # f: [0, 2pi]->complex
+    def f(self, alpha: float) -> complex:
+        pass
+
+    # f_derivative: [0, 2pi]->complex
+    def f_derivative(self, alpha: float) -> complex:
+        pass
+
+    def single_section_list(self):
+        this_contour = self
+
+        class DirectSection(Section):
+            def interpolate(self, a) -> complex:
+                return this_contour.f(2 * math.pi * a)
+
+            def evaluateDerivative(self, a) -> complex:
+                return this_contour.f_derivative(2 * math.pi * a) * 2 * math.pi  ## chain-rule
+
+        return [DirectSection()]

--- a/mule_local/python/mule_local/rexi/pcirexi/contour/EllipseContour.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/contour/EllipseContour.py
@@ -1,0 +1,19 @@
+import math
+
+from mule_local.rexi.pcirexi.contour.Contour import Contour
+
+
+class EllipseContour(Contour):
+
+    def __init__(self, horizontal_radius: float, vertical_radius: float, center: complex):
+        self.center = center
+        self.vertical_radius = vertical_radius
+        self.horizontal_radius = horizontal_radius
+
+    # f: [0, 2pi]->complex
+    def f(self, alpha: float) -> complex:
+        return self.center + self.horizontal_radius * math.cos(alpha) + 1j * self.vertical_radius * math.sin(alpha)
+
+    # f_derivative: [0, 2pi]->complex
+    def f_derivative(self, alpha: float) -> complex:
+        return -self.horizontal_radius * math.sin(alpha) + 1j * self.vertical_radius * math.cos(alpha)

--- a/mule_local/python/mule_local/rexi/pcirexi/contour/FunctionContour.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/contour/FunctionContour.py
@@ -1,0 +1,36 @@
+from cmath import *
+import sympy as sym
+
+from mule_local.rexi.pcirexi.contour.Contour import Contour
+
+
+class FunctionContour(Contour):
+    _expression: str
+    _expression_derivative: str
+
+    ### expression gets evaluated by system. Parameter is "alpha"
+    ### unit_circle: expression = "exp(alpha*1j)"
+    def __init__(self, expression: str):
+        self._expression = expression
+
+        ### symbolic differentiation:
+        sym_exp = sym.parsing.sympy_parser.parse_expr(expression)
+        sym_exp_diff = sym.diff(sym_exp)
+        self._expression_derivative = str(sym_exp_diff).replace("I", "1j")
+
+    # f: [0, 2pi]->complex
+    def f(self, alpha: float) -> complex:
+        try:
+            return eval(self._expression)
+        except:
+            print("Problem with evaluating the contour function")
+            return 0
+
+    # f_derivative: [0, 2pi]->complex
+    def f_derivative(self, alpha: float) -> complex:
+        try:
+            return eval(self._expression_derivative)
+        except:
+            print("Problem with evaluating contour derivative")
+            return 0
+        pass

--- a/mule_local/python/mule_local/rexi/pcirexi/contour/RectangleContour.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/contour/RectangleContour.py
@@ -1,0 +1,42 @@
+import math
+
+from mule_local.rexi.pcirexi.contour.Contour import Contour
+
+
+class RectangleContour(Contour):
+
+    def __init__(self, horizontal_radius: float, vertical_radius: float, center: complex):
+
+        self.center = center
+        self.height = vertical_radius
+        self.width = horizontal_radius
+
+    # f: [0, 2pi]->complex
+    def f(self, alpha: float) -> complex:
+        alpha %= (2 * math.pi)
+        if alpha <= math.pi / 2:
+            return 1j * (-self.height / 2 + alpha * self.height / (math.pi / 2)) + self.width / 2 + self.center
+        elif alpha <= math.pi:
+            alpha -= math.pi / 2
+            return (self.width / 2 - alpha * self.width / (math.pi / 2)) + self.height / 2 * 1j + self.center
+        elif alpha <= 3 * math.pi / 2:
+            alpha -= math.pi
+            return 1j * (self.height / 2 - alpha * self.height / (math.pi / 2)) - self.width / 2 + self.center
+        else:
+            alpha -= 3 * math.pi / 2
+            return (-self.width / 2 + alpha * self.width / (math.pi / 2)) - self.height / 2 * 1j + self.center
+
+    # f_derivative: [0, 2pi]->complex
+    def f_derivative(self, alpha: float) -> complex:
+        alpha %= (2 * math.pi)
+        if alpha <= math.pi / 2:
+            return 1j * (self.height / (math.pi / 2))
+        elif alpha <= math.pi:
+            alpha -= math.pi / 2
+            return (-self.width / (math.pi / 2))
+        elif alpha <= 3 * math.pi / 2:
+            alpha -= math.pi
+            return 1j * (-self.height / (math.pi / 2))
+        else:
+            alpha -= 3 * math.pi / 2
+            return (self.width / (math.pi / 2))

--- a/mule_local/python/mule_local/rexi/pcirexi/gauss_cache.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/gauss_cache.py
@@ -1,0 +1,64 @@
+from os import path
+from sympy.integrals.quadrature import gauss_legendre as g_le, gauss_lobatto as g_lo
+import pickle
+
+from mule_local.rexi.pcirexi.section.arbitrary_spline_basis_generator import generate_basis_polynomials
+
+
+class GaussCache:
+    lobatto_dict: dict
+    legendre_dict: dict
+    spline_dict: dict
+    file_path: str
+
+    def __init__(self, file_path='gauss_cache.pkl'):
+        self.file_path = file_path
+        if path.isfile(file_path):
+            file = open(self.file_path, "rb")
+            pickle_load = pickle.load(file)
+            if len(pickle_load) == 2:
+                self.spline_dict = {}
+                self.legendre_dict, self.lobatto_dict = pickle_load
+            else:
+                self.legendre_dict, self.lobatto_dict, self.spline_dict = pickle_load
+            file.close()
+        else:
+            self.legendre_dict = {}
+            self.lobatto_dict = {}
+            self.spline_dict = {}
+
+    def gauss_legendre(self, points, accuracy):
+        if (points, accuracy) in self.legendre_dict:
+            return self.legendre_dict[(points, accuracy)]
+        else:
+            print("run " + str(points) + " ac: " + str(accuracy))
+            value = g_le(points, accuracy)
+            self.legendre_dict[(points, accuracy)] = value
+            self.pickle_dicts()
+            return value
+
+    def gauss_lobatto(self, points, accuracy):
+        if (points, accuracy) in self.lobatto_dict:
+            return self.lobatto_dict[(points, accuracy)]
+        else:
+            print("run " + str(points) + " ac: " + str(accuracy))
+            value = g_lo(points, accuracy)
+            self.lobatto_dict[(points, accuracy)] = value
+            self.pickle_dicts()
+            return value
+
+    def spline_basis_polynomials(self, samples, n, precision):
+        tuple = (samples, n, precision)
+        if tuple in self.spline_dict:
+            return self.spline_dict[tuple]
+        else:
+            print("run ")
+            value = generate_basis_polynomials(samples, n, precision)
+            self.spline_dict[tuple] = value
+            self.pickle_dicts()
+            return value
+
+    def pickle_dicts(self):
+        file = open(self.file_path, "wb")
+        pickle.dump((self.legendre_dict, self.lobatto_dict, self.spline_dict), file)
+        file.close()

--- a/mule_local/python/mule_local/rexi/pcirexi/section/InterpolationSettings.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/section/InterpolationSettings.py
@@ -1,0 +1,14 @@
+class InterpolationSettings:
+    section_number: int = 1
+    interp_per_section: int = 2
+    interp_method: str = 'equidistant'
+    same_arc_length_for_all_sections: bool = False
+    sample_nodes_based_on_arc_length: bool = True
+
+    def __init__(self, section_number, interp_per_section, interp_method, same_arc_length_for_all_sections,
+                 sample_nodes_based_on_arc_length):
+        self.section_number = section_number
+        self.interp_method = interp_method
+        self.interp_per_section = interp_per_section
+        self.same_arc_length_for_all_sections = same_arc_length_for_all_sections
+        self.sample_nodes_based_on_arc_length = sample_nodes_based_on_arc_length

--- a/mule_local/python/mule_local/rexi/pcirexi/section/QuadratureSettings.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/section/QuadratureSettings.py
@@ -1,0 +1,9 @@
+class QuadratureSettings:
+    overall_quadrature_points: int = 1
+    quadrature_method: str = "midpoint"
+    distribute_quad_points_based_on_arc_length: bool = False
+
+    def __init__(self, overall_quadrature_points, quadrature_method, distribute_quad_points_based_on_arc_length):
+        self.overall_quadrature_points = overall_quadrature_points
+        self.quadrature_method = quadrature_method
+        self.distribute_quad_points_based_on_arc_length = distribute_quad_points_based_on_arc_length

--- a/mule_local/python/mule_local/rexi/pcirexi/section/arbitrary_spline.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/section/arbitrary_spline.py
@@ -1,0 +1,135 @@
+from typing import List, Any
+import mpmath
+
+from mule_local.rexi.pcirexi.gauss_cache import GaussCache
+from mule_local.rexi.pcirexi.section.polynomial_section import PolynomialSection
+
+
+class ArbitrarySpline:
+    a_list = []
+    y_list = []
+    coefficients: List[List[Any]]
+
+    def __init__(self, degree, start_a, end_a, a_list, y_list):
+        if len(a_list) < (degree - 2) * 2 or len(a_list) % (degree - 2) != 0:
+            raise
+        mpmath.mp.prec = 100
+        self.degree = degree
+        self.start_a = start_a
+        self.end_a = end_a
+        self.a_list = a_list
+        self.y_list = y_list
+        self.g_c = GaussCache()
+        self._calculate_coefficients()
+
+    def get_spline_nr(self, a):
+        jump_size = len(self.a_list) // 2
+        current_pos = jump_size
+        jump_size //= 2
+        if jump_size == 0:
+            jump_size = 1
+        while True:
+            if a < self.a_list[current_pos]:
+                current_pos -= jump_size
+            elif current_pos == len(self.a_list) - 1 or a < self.a_list[current_pos + 1]:
+                return current_pos // (self.degree - 2)
+            else:
+                current_pos += jump_size
+            jump_size //= 2
+            if jump_size == 0:
+                jump_size = 1
+
+    def interpolate_list(self, a_interpol_list):
+        y_interpol_list = []
+        for cur_a in a_interpol_list:
+            y_interpol_list.append(self.evaluate(cur_a))
+        return y_interpol_list
+
+    def evaluate(self, a):
+        spline_nr = self.get_spline_nr(a)
+        a = (a - self.a_list[spline_nr * (self.degree - 2)]) / self.h(spline_nr * (self.degree - 2))
+        sum = 0j
+        exponent = 1
+        for i in range(0, len(self.coefficients[spline_nr])):
+            sum += exponent * self.coefficients[spline_nr][i]
+            exponent = mpmath.mpf.pow(a, i + 1)
+            # exponent *= a
+        return sum
+
+    def get_polynomial_sections(self):
+        poly_sections = []
+        for i in range(len(self.coefficients)):
+            a_0 = self.a_list[i * (self.degree - 2)]
+            if i + 1 == len(self.coefficients):
+                a_1 = self.end_a
+            else:
+                a_1 = self.a_list[(i * (self.degree - 2) + (self.degree - 2)) % len(self.a_list)]
+            poly_sections.append(PolynomialSection(a_0, a_1, coefficients=self.coefficients[i]))
+        return poly_sections
+
+    def _calculate_coefficients(self):
+        basis_polynomials = [self.g_c.spline_basis_polynomials(samples=self.degree - 1, n=i, precision=mpmath.mp.prec)
+                             for i in range(0, self.degree - 1 + 2)]
+        basis_polynomials_coefficients = [b_p.coefficients for b_p in basis_polynomials]
+        second_derivatives = [b_p.second_derivation_coefficients for b_p in basis_polynomials]
+        t_0_factors = [s_d[0] for s_d in second_derivatives]
+        t_1_factors = [sum(s_d) for s_d in second_derivatives]
+
+        A: List[List[int]] = []
+        A_prime = []
+        b: List[Any] = []
+        step = (self.degree - 2)
+        size = len(self.a_list) // step
+        for i in range(size):
+            row = []
+            row_prime = []
+            for j in range(size):
+                pos = (((j + 1) % size) - i) % size
+                h_minus = self.h(i * step - step)
+                h = self.h(i * step)
+                row.append(t_1_factors[-2] / h_minus if pos == 0 else
+                           (t_1_factors[-1] / h_minus - t_0_factors[-2] / h if
+                            pos == 1 else -t_0_factors[-1] / h if
+                           pos == 2 else 0))
+                row_prime.append(pos)
+            A.append(row)
+            A_prime.append(row_prime)
+        for i in range(size):
+            h_minus = self.h(i * step - step)
+            h = self.h(i * step)
+            newValue = 0
+            for j in range(step + 1):
+                newValue += -t_1_factors[j] * self.y_list[i * step - step + j] / h_minus / h_minus + t_0_factors[j] * \
+                            self.y_list[(i * step + j) % len(self.y_list)] / h / h
+            b.append(newValue)
+        derivations = mpmath.lu_solve(A, b)
+        self.coefficients = []
+        for i in range(size):
+            current_coefficients = [0j] * (self.degree + 1)
+            if len(current_coefficients) != len(basis_polynomials_coefficients):
+                raise
+            for j in range(step + 1):
+                for h in range(len(basis_polynomials_coefficients[j])):
+                    current_coefficients[h] += basis_polynomials_coefficients[j][h] * self.y_list[
+                        (i * step + j) % len(self.y_list)]
+            for h in range(len(basis_polynomials_coefficients[-2])):
+                current_coefficients[h] += basis_polynomials_coefficients[-2][h] * derivations[i] * self.h(i * step)
+            for h in range(len(basis_polynomials_coefficients[-1])):
+                current_coefficients[h] += basis_polynomials_coefficients[-1][h] * derivations[
+                    (i + 1) % len(derivations)] * self.h(i * step)
+            current_coefficients = [complex(c_c) for c_c in current_coefficients]
+
+            self.coefficients.append(current_coefficients)
+        return
+
+    def h(self, i):
+        if i % (self.degree - 2) != 0:
+            raise
+        i = i % len(self.a_list)
+        if i == len(self.a_list) - (self.degree - 2):
+            a_plus = self.end_a
+            a = self.a_list[i]
+        else:
+            a_plus = self.a_list[i + (self.degree - 2)]
+            a = self.a_list[i]
+        return a_plus - a

--- a/mule_local/python/mule_local/rexi/pcirexi/section/arbitrary_spline_basis_generator.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/section/arbitrary_spline_basis_generator.py
@@ -1,0 +1,29 @@
+import mpmath
+
+from mule_local.rexi.pcirexi.section.polynomial_section import PolynomialSection
+
+
+def generate_basis_polynomials(samples, n, precision, calc_condition=False):
+    mpmath.mp.prec = precision
+    A = []
+    for i in range(samples):
+        line = []
+        for j in range(samples + 2):
+            t = mpmath.mpf(1) / (samples - 1) * i
+            line.append(t ** j)
+        A.append(line)
+    for t in range(2):
+        line = []
+        for j in range(samples + 2):
+            if j == 0:
+                line.append(mpmath.mpf(0.0))
+            else:
+                line.append(mpmath.mpf(j) * (t ** (j - 1)))
+        A.append(line)
+    b = [mpmath.mpf(0)] * n + [mpmath.mpf(1)] + [mpmath.mpf(0)] * (samples + 2 - n - 1)
+    if calc_condition:
+        basis_condition = mpmath.cond(A)
+        return basis_condition
+    x = mpmath.lu_solve(A, b)
+    # x = [float(v) for v in mpmath.mp.lu_solve(A,b)]
+    return PolynomialSection(0, 1, coefficients=[element for element in x])

--- a/mule_local/python/mule_local/rexi/pcirexi/section/circle_section.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/section/circle_section.py
@@ -1,0 +1,29 @@
+from cmath import exp
+from math import pi
+
+from mule_local.rexi.pcirexi.section.section import Section
+
+
+class CircleSection(Section[float, float]):
+    end_a: float
+
+    def __init__(self, start_a, end_a, r=10):
+        self.start_a = start_a
+        self.end_a = end_a
+        self.r = r
+
+    def interpolate(self, a) -> complex:
+        return self.r * exp(1j * (self.start_a + (self.end_a - self.start_a) * a))  # +1
+
+    def evaluate_input(self, a) -> complex:
+        return 2j * (pi * a / self.end_a)
+
+    def evaluateDerivative(self, a) -> float:
+        return self.r * 1j * (self.end_a - self.start_a) * exp(1j * (self.start_a + (self.end_a - self.start_a) * a))
+
+    def evaluate_derivative_parameterized(self, a) -> float:
+        return self.r * 1j * exp(1j * (self.start_a + (self.end_a - self.start_a) * a))
+
+    def sub_sections(self, amount: int):
+        raise
+        return [CircleSection(1)]

--- a/mule_local/python/mule_local/rexi/pcirexi/section/contour_generator.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/section/contour_generator.py
@@ -1,0 +1,40 @@
+import cmath
+import numpy as np
+
+
+def ellipse(radius, rfactor, ifactor):
+    def contour(alpha, to_string=False):
+        if to_string:
+            return "ellipse(" + str(radius * rfactor) + ", " + str(radius * ifactor) + ")"
+        value = radius * cmath.exp(1j * alpha)
+        return value.real * rfactor + value.imag * ifactor * 1j
+
+    return contour
+
+
+def stick(radius, cube_radius):
+    def contour(alpha, to_string=False):
+        if to_string:
+            return "stick(" + str(radius) + ", " + str(cube_radius) + ")"
+        value = radius * cmath.exp(1j * alpha)
+        if alpha < np.pi / 4:
+            return radius + 1j * alpha / (np.pi / 4) * cube_radius
+        elif alpha < 3 / 4 * np.pi:
+            return radius * cmath.exp((alpha - np.pi / 4) * 2j) + cube_radius * 1j
+        elif alpha < 5 / 4 * np.pi:
+            return 0 - radius + 1j * (np.pi - alpha) / (np.pi / 4) * cube_radius
+        elif alpha < 7 / 4 * np.pi:
+            return radius * cmath.exp(np.pi * 1j + (alpha - np.pi * 5 / 4) * 2j) - cube_radius * 1j
+        else:
+            return radius + 1j * (alpha - 2 * np.pi) / (np.pi / 4) * cube_radius
+
+    return contour
+
+
+def circle(radius):
+    def contour(alpha, to_string=False):
+        if to_string:
+            return "circle(" + str(radius) + ")"
+        return 1j * radius * cmath.exp(alpha * 1j)
+
+    return contour

--- a/mule_local/python/mule_local/rexi/pcirexi/section/cubic_spline.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/section/cubic_spline.py
@@ -1,0 +1,249 @@
+import math
+from typing import List, Any
+import numpy as np
+
+from mule_local.rexi.pcirexi.section.polynomial_section import PolynomialSection
+
+
+class CubicSpline:
+    a_list = []
+    y_list = []
+    coefficients: List[List[Any]]
+
+    def __init__(self, start_a, end_a, a_list, y_list):
+        self.start_a = start_a
+        self.end_a = end_a
+        self.a_list = a_list
+        self.y_list = y_list
+        self.calculate_coefficients()
+        self.calculate_derivation_coefficients()
+
+    def get_spline_nr(self, a):
+        jump_size = len(self.a_list) // 2
+        current_pos = jump_size
+        jump_size //= 2
+        if jump_size == 0:
+            jump_size = 1
+        while True:
+            if a < self.a_list[current_pos]:
+                current_pos -= jump_size
+            elif current_pos == len(self.a_list) - 1 or a < self.a_list[current_pos + 1]:
+                return current_pos
+            else:
+                current_pos += jump_size
+            jump_size //= 2
+            if jump_size == 0:
+                jump_size = 1
+
+    def interpolate(self, a_interpol_list):
+        y_interpol_list = []
+        for cur_a in a_interpol_list:
+            y_interpol_list.append(self.evaluatePolynome(cur_a))
+        return y_interpol_list
+
+    def evaluate(self, a):
+        spline_nr = self.get_spline_nr(a)
+        a = (a - self.a_list[spline_nr]) / self.h(spline_nr)
+        sum = 0j
+        exponent = 1
+        for i in range(0, len(self.coefficients[spline_nr])):
+            sum += exponent * self.coefficients[spline_nr][i]
+            exponent = math.pow(a, i + 1)
+            # exponent *= a
+        return sum
+
+    def evaluateDerivative(self, a):
+        spline_nr = self.get_spline_nr(a)
+        a = (a - self.a_list[spline_nr]) / self.h(spline_nr)
+        sum = 0j
+        exponent = 1
+        for i in range(0, len(self.derivation_coefficients[spline_nr])):
+            sum += exponent * self.derivation_coefficients[spline_nr][i]
+            exponent = math.pow(a, i + 1)
+        return sum / self.h(spline_nr)
+
+    def calculateDerivationCoefficients(self):
+        self.derivation_coefficients = [0j] * (len(self.coefficients) - 1)
+        for i in range(1, len(self.coefficients)):
+            self.derivation_coefficients[i - 1] = self.coefficients[i] * i
+
+    def get_polynomial_sections(self):
+        poly_sections = []
+        for i in range(len(self.a_list)):
+            a_0 = self.a_list[i]
+            if i + 1 == len(self.a_list):
+                a_1 = self.end_a
+            else:
+                a_1 = self.a_list[(i + 1) % len(self.a_list)]
+            poly_sections.append(PolynomialSection(a_0, a_1, coefficients=self.coefficients[i]))
+        return poly_sections
+
+    def calculate_coefficients(self):
+        A: List[List[int]] = []
+        b: List[Any] = []
+        for i in range(len(self.a_list)):
+            row = []
+            for j in range(len(self.a_list)):
+                pos = (((j + 1) % len(self.a_list)) - i) % len(self.a_list)
+                h_minus = self.h(i - 1)
+                h = self.h(i)
+                row.append(1 / h_minus if pos == 0 else
+                           (2 / h_minus + 2 / h if
+                            pos == 1 else 1 / h if
+                           pos == 2 else 0))
+            A.append(row)
+        for i in range(len(self.a_list)):
+            h_minus = self.h(i - 1)
+            h = self.h(i)
+            b.append(3 * ((self.y_list[i] - self.y_list[(i - 1) % len(self.a_list)]) / (h_minus * h_minus)
+                          + (self.y_list[(i + 1) % len(self.a_list)] - self.y_list[i]) / (h * h)))
+        #            b.append((self.y_list[(i + 1) % len(self.a_list)] - self.y_list[(i-1) % len(self.a_list)])/(self.a_list[1]-self.a_list[0])*3)
+        derivations = np.linalg.solve(A, b)
+        self.coefficients = []
+        for i in range(len(self.a_list)):
+            current_coefficients = [0j] * 4
+            current_coefficients[0] = self.y_list[i]
+            h = self.h(i)
+            current_coefficients[1] = derivations[i] * h
+            current_coefficients[2] = -3 * self.y_list[i] + 3 * self.y_list[(i + 1) % len(self.a_list)] - 2 * \
+                                      derivations[i] * h - derivations[(i + 1) % len(self.a_list)] * h
+            current_coefficients[3] = 2 * self.y_list[i] - 2 * self.y_list[(i + 1) % len(self.a_list)] + derivations[
+                i] * h + derivations[(i + 1) % len(self.a_list)] * h
+            self.coefficients.append(current_coefficients)
+
+    def calculate_coefficients2(self):
+        A: List[List[int]] = []
+        b: List[Any] = []
+        for i in range(len(self.a_list)):
+            row = []
+            for j in range(len(self.a_list)):
+                pos = (((j + 1) % len(self.a_list)) - i) % len(self.a_list)
+                row.append(1 / 6 if pos == 0 else
+                           (2 / 3 if
+                            pos == 1 else 1 / 6 if
+                           pos == 2 else 0))
+            A.append(row)
+            print(row)
+
+        for i in range(len(self.a_list)):
+            h_minus = self.h(i - 1)
+            h = self.h(i)
+            y_i_p = self.y_list[(i + 1) % len(self.a_list)]
+            y_i = self.y_list[i]
+            y_i_m = self.y_list[(i - 1) % len(self.a_list)]
+            b.append(y_i_p - 2 * y_i + y_i_m)
+        #            b.append((self.y_list[(i + 1) % len(self.a_list)] - self.y_list[(i-1) % len(self.a_list)])/(self.a_list[1]-self.a_list[0])*3)
+        derivations = np.linalg.solve(A, b)
+        self.coefficients = []
+        for i in range(len(self.a_list)):
+            current_coefficients = [0j] * 4
+            current_coefficients[0] = self.y_list[i]
+            y_i_p = self.y_list[(i + 1) % len(self.y_list)]
+            y_i = self.y_list[i]
+            M_i = derivations[i]
+            M_i_p = derivations[(i + 1) % len(derivations)]
+            current_coefficients[1] = -1 / 2 * M_i + y_i_p - y_i - (M_i_p - M_i) / 6
+            current_coefficients[2] = 1 / 2 * M_i
+            current_coefficients[3] = -1 / 6 * M_i + 1 / 6 * M_i_p
+            self.coefficients.append(current_coefficients)
+
+    def calculate_coefficients3(self):
+        A: List[List[int]] = []
+        b: List[Any] = []
+        for i in range(len(self.a_list)):
+            row = []
+            for j in range(len(self.a_list)):
+                pos = (((j + 1) % len(self.a_list)) - i) % len(self.a_list)
+                h_minus = self.h(i - 1)
+                h = self.h(i)
+                row.append(h_minus / 6 if pos == 0 else
+                           ((h_minus + h) / 3 if
+                            pos == 1 else h / 6 if
+                           pos == 2 else 0))
+            A.append(row)
+            print(row)
+
+        for i in range(len(self.a_list)):
+            h_minus = self.h(i - 1)
+            h = self.h(i)
+            y_i_p = self.y_list[(i + 1) % len(self.a_list)]
+            y_i = self.y_list[i]
+            y_i_m = self.y_list[(i - 1) % len(self.a_list)]
+            b.append((y_i_p - y_i) / h - (y_i - y_i_m / h_minus))
+        #            b.append((self.y_list[(i + 1) % len(self.a_list)] - self.y_list[(i-1) % len(self.a_list)])/(self.a_list[1]-self.a_list[0])*3)
+        derivations = np.linalg.solve(A, b)
+        self.coefficients = []
+        for i in range(len(self.a_list)):
+            current_coefficients = [0j] * 4
+            h = self.h(i)
+            y_i_p = self.y_list[(i + 1) % len(self.y_list)]
+            y_i = self.y_list[i]
+            M_i = derivations[i]
+            M_i_p = derivations[(i + 1) % len(derivations)]
+            # current_coefficients[0] = self.y_list[i]
+            # current_coefficients[1] = -1 / 2 *h**2 *M_i + y_i_p - y_i - h**2*(M_i_p - M_i)/6
+            # current_coefficients[2] = 1/2*M_i*h**2
+            # current_coefficients[3] = -1/6*M_i*h**2 + 1/6*M_i_p*h**2
+            current_coefficients[0] = self.y_list[i]
+            current_coefficients[1] = -1 / 2 * h ** 2 * M_i + y_i_p - y_i - (h ** 2) * (M_i_p - M_i) / 6
+            current_coefficients[2] = 1 / 2 * h ** 2 * M_i
+            current_coefficients[3] = -1 / 6 * h ** 2 * M_i + 1 / 6 * h ** 2 * M_i_p
+            self.coefficients.append(current_coefficients)
+
+    def calculate_coefficients4(
+            self):  # setting s_n'(alpha_n + 0*(alpha_(n+1)-alpha_n)) =s_n_1'(alpha_n + 1*(alpha_(n+1)-alpha_n))
+        A: List[List[int]] = []
+        b: List[Any] = []
+        for i in range(len(self.a_list)):
+            row = []
+            for j in range(len(self.a_list)):
+                pos = (((j + 1) % len(self.a_list)) - i) % len(self.a_list)
+                h_minus = self.h(i - 1)
+                h = self.h(i)
+                row.append((h_minus ** 2) / 6 if pos == 0 else
+                           ((h_minus ** 2) / 3 + (h ** 2) / 3 if
+                            pos == 1 else (h ** 2) / 6 if
+                           pos == 2 else 0))
+            A.append(row)
+            print(row)
+
+        for i in range(len(self.a_list)):
+            h_minus = self.h(i - 1)
+            h = self.h(i)
+            y_i_p = self.y_list[(i + 1) % len(self.a_list)]
+            y_i = self.y_list[i]
+            y_i_m = self.y_list[(i - 1) % len(self.a_list)]
+            b.append((y_i_p - y_i) - (y_i - y_i_m))
+        #            b.append((self.y_list[(i + 1) % len(self.a_list)] - self.y_list[(i-1) % len(self.a_list)])/(self.a_list[1]-self.a_list[0])*3)
+        derivations = np.linalg.solve(A, b)
+        self.coefficients = []
+        for i in range(len(self.a_list)):
+            current_coefficients = [0j] * 4
+            current_coefficients[0] = self.y_list[i]
+            h = self.h(i)
+            y_i_p = self.y_list[(i + 1) % len(self.y_list)]
+            y_i = self.y_list[i]
+            M_i = derivations[i]
+            M_i_p = derivations[(i + 1) % len(derivations)]
+            current_coefficients[1] = -1 / 2 * h ** 2 * M_i + y_i_p - y_i - h ** 2 * (M_i_p - M_i) / 6
+            current_coefficients[2] = 1 / 2 * M_i * h ** 2
+            current_coefficients[3] = -1 / 6 * M_i * h ** 2 + 1 / 6 * M_i_p * h ** 2
+            self.coefficients.append(current_coefficients)
+
+    def h(self, i):
+        i = i % len(self.a_list)
+        if i == len(self.a_list) - 1:
+            a_plus = self.end_a
+            a = self.a_list[i]
+        else:
+            a_plus = self.a_list[i + 1]
+            a = self.a_list[i]
+        return a_plus - a
+
+    def calculate_derivation_coefficients(self):
+        self.derivation_coefficients = []
+        for i in range(len(self.coefficients)):
+            current_derivation_coefficients = [0j] * (len(self.coefficients[0]) - 1)
+            for j in range(1, len(self.coefficients[0])):
+                current_derivation_coefficients[j - 1] = self.coefficients[i][j] * j
+            self.derivation_coefficients.append(current_derivation_coefficients)

--- a/mule_local/python/mule_local/rexi/pcirexi/section/polynomial_section.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/section/polynomial_section.py
@@ -1,0 +1,159 @@
+import math
+from typing import List
+
+import numpy as np
+import scipy.special
+from numpy import polyfit
+
+from mule_local.rexi.pcirexi.section.section import Section
+
+
+class PolynomialSection(Section):
+    coefficients = []
+    derivation_coefficients = []
+    second_derivation_coefficients = []
+    x_list = []
+    y_list = []
+
+    def __init__(self, start_a, end_a, a_list: List = None, y_list: List = None, coefficients=None, methode='newton'):
+        self.start_a = start_a
+        self.end_a = end_a
+        if a_list is None or y_list is None:
+            self.coefficients = coefficients
+        else:
+            self.a_list = a_list
+            self.y_list = y_list
+            if methode == 'newton':
+                newton_coefficients = self._calculate_newton_coefficients(a_list, y_list)
+                self._calculate_coefficients(newton_coefficients)
+            elif methode == 'polyfit':
+                self.coefficients = [polyfit(a_list, y_list, -1 + len(a_list))[::-1]][0]
+            else:
+                self._calculate_coefficients_via_linear_equation_system(a_list, y_list)
+        self._calculate_derivation_coefficients()
+
+    def _calculate_newton_coefficients(self, a_list, y_list):
+        newtonTable = []
+        newton_coefficients = []
+        newtonTable.append(y_list)
+        newton_coefficients.append(y_list[0])
+        for k in range(1, len(a_list)):
+            newtonTable.append([])
+            for i in range(0, len(a_list) - k):
+                newtonTable[k].append((newtonTable[k - 1][i + 1] - newtonTable[k - 1][i]) / (a_list[i + k] - a_list[i]))
+            newton_coefficients.append(newtonTable[k][0])
+        return newton_coefficients
+
+    def interpolate_list(self, a_interpol_list):
+        y_interpol_list = []
+        for cur_a in a_interpol_list:
+            y_interpol_list.append(self.interpolate(cur_a))
+        return y_interpol_list
+
+    def interpolate(self, a):
+        sum = 0j
+        exponent = 1
+        for i in range(0, len(self.coefficients)):
+            sum += exponent * self.coefficients[i]
+            exponent = math.pow(a, i + 1)
+        return sum
+
+    def evaluateDerivative(self, a):
+        sum = 0j
+        exponent = 1
+        for i in range(0, len(self.derivation_coefficients)):
+            sum += exponent * self.derivation_coefficients[i]
+            exponent = math.pow(a, i + 1)
+        return sum
+
+    def evaluate_derivative_parameterized(self, a):
+        sum = 0j
+        exponent = 1
+        for i in range(0, len(self.derivation_coefficients)):
+            sum += exponent * self.derivation_coefficients[i]
+            exponent = math.pow(a, i + 1)
+        return sum / (self.end_a - self.start_a)
+
+    def evaluate_second_derivative(self, a):
+        sum = 0j
+        exponent = 1
+        for i in range(0, len(self.second_derivation_coefficients)):
+            sum += exponent * self.second_derivation_coefficients[i]
+            exponent = math.pow(a, i + 1)
+        #    exponent *= a
+        return sum
+
+    def evaluate_second_derivative_parameterized(self, a):
+        sum = 0j
+        exponent = 1
+        for i in range(0, len(self.second_derivation_coefficients)):
+            sum += exponent * self.second_derivation_coefficients[i]
+            exponent = math.pow(a, i + 1)
+        #    exponent *= a
+        return sum / (self.end_a - self.start_a) / (self.end_a - self.start_a)
+
+    def _calculate_coefficients(self, newton_coefficients):
+        self.coefficients = [0j] * len(newton_coefficients)
+        for i in range(0, len(newton_coefficients)):
+            coefficient_part = [0j] * len(newton_coefficients)
+            self._recursive_coefficient(coefficient_part, 0, 1, 0, i - 1)
+            coefficient_part = list(map(lambda c_p: c_p * newton_coefficients[i], coefficient_part))
+            self.coefficients = [x + y for (x, y) in zip(coefficient_part, self.coefficients)]
+
+    def _recursive_coefficient(self, coefficient_part, degree, value, index, max_index):
+        if index > max_index:
+            coefficient_part[degree] += value
+            return
+        self._recursive_coefficient(coefficient_part, degree + 1, value, index + 1, max_index)
+        self._recursive_coefficient(coefficient_part, degree, -value * self.a_list[index], index + 1, max_index)
+        return
+
+    def _calculate_derivation_coefficients(self):
+        self.derivation_coefficients = [0j] * (len(self.coefficients) - 1)
+        self.second_derivation_coefficients = [0j] * (len(self.coefficients) - 2)
+        for i in range(1, len(self.coefficients)):
+            self.derivation_coefficients[i - 1] = self.coefficients[i] * i
+        for i in range(2, len(self.coefficients)):
+            self.second_derivation_coefficients[i - 2] = self.coefficients[i] * i * (i - 1)
+
+    def sub_sections(self, amount):
+        ## First calculate seperation points
+        borders = [self.start_a] + [self.end_a] * amount
+        for i in range(1, amount):
+            last_to_end_length = self.arc_length_start_end(borders[i - 1], self.end_a)
+            sub_length = last_to_end_length / (amount - i + 1)
+            distance = sub_length - last_to_end_length
+            jump_size = (self.end_a - borders[i - 1]) / 2
+            steps = 1
+            while abs(distance) > sub_length / 1000000000000000:
+                print("Steps: " + str(steps))
+                steps += 1
+                if distance > 0:
+                    borders[i] += jump_size
+                else:
+                    borders[i] -= jump_size
+                jump_size /= 2
+                distance = sub_length - self.arc_length_start_end(borders[i - 1], borders[i])
+        subCoefficient = []
+        subSections = []
+        ### Paremetrization to alpha \in [0,1]
+        for i in range(0, amount):
+            subCoefficient.append([0.0] * len(self.coefficients))
+            ### coefficients from    a_0*1 + a_1*x                         + a_2*x^2
+            ###             to       a_0*1 + a_1*(x*(end-start) + start)   + a_2*(x*(end-start) + start)^2
+            for n in range(0, len(self.coefficients)):
+                for k in range(0, n + 1):
+                    binom = scipy.special.binom(n, k)
+                    subCoefficient[i][n - k] += binom * self.coefficients[n] * math.pow(borders[i + 1] - borders[i],
+                                                                                        n - k) * math.pow(borders[i], k)
+            subSections.append(PolynomialSection(0.0, 1.0, coefficients=subCoefficient[i]))
+        return subSections
+
+    def _calculate_coefficients_via_linear_equation_system(self, a_list, y_list):
+        A = []
+        for a in a_list:
+            line = []
+            for j in range(len(a_list)):
+                line.append(math.pow(a, j))
+            A.append(line)
+        self.coefficients = np.linalg.solve(A, y_list)

--- a/mule_local/python/mule_local/rexi/pcirexi/section/section.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/section/section.py
@@ -1,0 +1,29 @@
+from typing import TypeVar, Generic, List
+
+import scipy.integrate as integrate
+
+A_T = TypeVar('A_T')
+Y_T = TypeVar('Y_T')
+
+
+class Section(Generic[A_T, Y_T]):
+    start_a: A_T = 0
+    end_a: A_T = 0
+
+    def interpolate_list(self, a_interpol_list) -> List[Y_T]:
+        y_interpol_list: List[Y_T] = []
+        for cur_a in a_interpol_list:
+            y_interpol_list.append(self.interpolate(cur_a))
+        return y_interpol_list
+
+    def interpolate(self, a) -> Y_T:
+        pass
+
+    def evaluateDerivative(self, a) -> Y_T:
+        pass
+
+    def arc_length_start_end(self, start: A_T, end: Y_T):
+        return integrate.quad(lambda x: abs(self.evaluateDerivative(x)), start, end)[0]
+
+    def sub_sections(self, amount: int):
+        pass

--- a/mule_local/python/mule_local/rexi/pcirexi/section/section_factory.py
+++ b/mule_local/python/mule_local/rexi/pcirexi/section/section_factory.py
@@ -1,0 +1,193 @@
+import math
+from random import uniform
+
+import numpy as np
+from typing import Callable
+
+from scipy import integrate
+from scipy.special import roots_chebyt
+
+
+# binary search for sample points that are distributed based on arc_length
+from mule_local.rexi.pcirexi.gauss_cache import GaussCache
+from mule_local.rexi.pcirexi.section.arbitrary_spline import ArbitrarySpline
+from mule_local.rexi.pcirexi.section.circle_section import CircleSection
+from mule_local.rexi.pcirexi.section.cubic_spline import CubicSpline
+from mule_local.rexi.pcirexi.section.polynomial_section import PolynomialSection
+
+
+def calculate_arc_length_based_function_points(alphas_function_base: [float], start_section: float, end_section: float,
+                                               f: Callable, f_derivative=None):
+    DERIVATION_STEP = 10 ** -7
+    ACCURACY = 10 ** -9
+    if f_derivative is None:
+        f_derivative = lambda a: (f(a + DERIVATION_STEP) - f(a - DERIVATION_STEP)) / 2 / DERIVATION_STEP
+    arc_length = integrate.quad(lambda x: abs(f_derivative(x)), start_section, end_section)[0]
+    accumulated_arc_lengths = [arc_length * (a - start_section) / (end_section - start_section) for a in
+                               alphas_function_base]
+    current_arc_length = 0
+    last_sample_point = start_section
+    sample_nodes = []
+    for current_goal_arc_length in accumulated_arc_lengths:
+        current_step = (end_section - last_sample_point) / 2
+        current_sample = last_sample_point + current_step
+        current_arc_length = integrate.quad(lambda x: abs(f_derivative(x)), start_section, current_sample)[0]
+        # while current_arc_length < current_goal_arc_length * (1 - ACCURACY) or current_arc_length >= current_goal_arc_length * (1 + ACCURACY):
+        while abs(current_arc_length - current_goal_arc_length) > ACCURACY and current_step != 0:
+            current_step /= 2
+            if current_arc_length >= current_goal_arc_length:
+                current_sample -= current_step
+            else:
+                current_sample += current_step
+            current_arc_length = integrate.quad(lambda x: abs(f_derivative(x)), start_section, current_sample)[0]
+        sample_nodes.append(current_sample)
+    return [f(s) for s in sample_nodes]
+
+
+class SectionFactory:
+    g_c: GaussCache
+
+    def __init__(self, g_c=GaussCache()):
+        self.g_c = g_c
+
+    def generate_sections(self, f: Callable, f_derivative, section_amount, points_per_section=1,
+                          interpolation='equidistant',
+                          methode='lgs', circle_radius=10, equilong=False,
+                          sample_points_arc_length_positioned=False):
+        if interpolation.startswith('cubicsplines'):
+            section_type = 'cubicsplines'
+        elif interpolation.startswith('spline'):
+            section_type = 'spline'
+        elif interpolation.startswith('circle'):
+            section_type = 'circle'
+        else:
+            section_type = 'polynomials'
+            interpolation = interpolation.split(' ')[0]
+            interpolation = interpolation.split(',')[0]
+        if equilong:
+            section_start_list = self.generate_equilong_section_start_list(f, f_derivative, section_amount)
+        else:
+            section_start_list = np.linspace(0, 2 * np.pi * (1 - 1 / section_amount), section_amount)
+
+        if section_type == 'polynomials':
+            interpolation_alphas = [a / 2 + 0.5 for a in
+                                    self._alphas_for_interpolation(interpolation, points_per_section)]
+            section_list = []
+            for n in range(0, section_amount):
+                if n == section_amount - 1:
+                    end_section = 2 * np.pi
+                else:
+                    end_section = section_start_list[n + 1]
+                alphas_function_base = [section_start_list[n] + (end_section - section_start_list[n]) * a for a in
+                                        interpolation_alphas]
+                if sample_points_arc_length_positioned:
+                    function_points = calculate_arc_length_based_function_points(alphas_function_base,
+                                                                                 section_start_list[n], end_section, f, f_derivative)
+                else:
+                    function_points = [f(a) for a in alphas_function_base]
+                section = PolynomialSection(section_start_list[n],
+                                            end_section, interpolation_alphas,
+                                            function_points, methode=methode)
+                section_list.append(section)
+            return section_list
+        elif section_type == 'cubicsplines':
+            interpolation_alphas = np.linspace(0, 2 * math.pi * (1 - 1 / section_amount), section_amount)
+            #            interpolation_alphas = [0] + sorted([uniform(0, 2*math.pi*(1-1/section_amount)) for i in range(1, section_amount)])
+            sample_alphas_orig = interpolation_alphas
+            sections = CubicSpline(0, 2 * math.pi, interpolation_alphas,
+                                   [f(a) for a in sample_alphas_orig]).get_polynomial_sections()
+            sample_alphas_base = np.linspace(0, 1, 40)
+            interpolation_alphas = []
+            ys = []
+            for section in sections:
+                interpolation_alphas += [a * (section.end_a - section.start_a) + section.start_a for a in
+                                         sample_alphas_base]
+                ys += [section.interpolate(a) for a in sample_alphas_base]
+            # gui.plot_list([y.real for y in ys], [y.imag for y in ys])
+            return sections
+        elif section_type == 'spline':
+            interpolation_alphas = np.linspace(0, 2 * math.pi * (1 - 1 / section_amount / (points_per_section - 1)),
+                                               section_amount * (points_per_section - 1))
+            #            interpolation_alphas = [0] + sorted([uniform(0, 2*math.pi*(1-1/section_amount)) for i in range(1, section_amount)])
+            sample_alphas_orig = interpolation_alphas
+            spline = ArbitrarySpline(points_per_section + 1, 0, 2 * math.pi, interpolation_alphas,
+                                     [f(a) for a in sample_alphas_orig])
+            sections = spline.get_polynomial_sections()
+            if methode == 'basis_condition_return':
+                return spline.basis_condition
+            if methode == 'overall_condition_return':
+                return spline.overall_condition
+            sample_alphas_base = np.linspace(0, 1, 40)
+            interpolation_alphas = []
+            ys = []
+            for section in sections:
+                interpolation_alphas += [a * (section.end_a - section.start_a) + section.start_a for a in
+                                         sample_alphas_base]
+                ys += [section.interpolate(a) for a in sample_alphas_base]
+            # gui.plot_list([y.real for y in ys], [y.imag for y in ys])
+            return sections
+        elif section_type == 'circle':
+            section_list = []
+            interpolation_alphas = np.linspace(0, 2 * math.pi * (1), section_amount + 1)
+            # interpolation_alphas = [0] + sorted([uniform(0, 2*math.pi*(1-1/section_amount)) for i in range(1, section_amount)]) + [2*math.pi]
+            for n in range(0, section_amount):
+                section_list.append(CircleSection(interpolation_alphas[n], interpolation_alphas[n + 1], circle_radius))
+            sample_alphas_base = np.linspace(0, 1, 40)
+            interpolation_alphas = []
+            ys = []
+            for section in section_list:
+                interpolation_alphas += [a * (section.end_a - section.start_a) + section.start_a for a in
+                                         sample_alphas_base]
+                ys += [section.evaluate_derivative_parameterized(a) for a in sample_alphas_base]
+            # gui.plot_list(interpolation_alphas, ys)
+            return section_list
+
+    def generate_equilong_section_start_list(self, f, f_derivative, section_amount):
+        section_start_list = [0] * section_amount
+        accuracy = 10 ** -10
+        left_length = \
+            integrate.quad(lambda x: abs(f_derivative(x)), 0, 2 * np.pi)[0]
+        current_pos = 0
+        current_width = 2 * np.pi
+        step = current_width / 2
+        for i in range(1, section_amount):
+            goal_length = left_length / (section_amount - i + 1)
+            cur_length = \
+                integrate.quad(lambda x: abs(f_derivative(x)), current_pos, current_pos + current_width)[0]
+            while cur_length < goal_length * (1 - accuracy) or cur_length >= goal_length * (1 + accuracy):
+                if cur_length >= goal_length * (1 + accuracy):
+                    current_width -= step
+                    step /= 2
+                else:
+                    current_width += step
+                    step /= 2
+                cur_length = \
+                    integrate.quad(lambda x: abs(f_derivative(x)),
+                                   current_pos, current_pos + current_width)[0]
+            current_pos = current_pos + current_width
+            section_start_list[i] = current_pos
+            left_length -= cur_length
+            current_width = left_length
+            step = current_width / 2
+        return section_start_list
+
+    def _alphas_for_interpolation(self, interpolation, sample_points):
+        sample_alphas = []
+        if interpolation == 'equidistant':
+            # print("Ip ed")
+            # with 1/(2*section) distance to bodrders
+            # sample_alphas = np.linspace(-1 + 1/(samples_per_section*2), 1 - 1/(2*samples_per_section), samples_per_section)
+            sample_alphas = np.linspace(-1, 1, sample_points)
+        elif interpolation == 'lobatto':
+            # print("Ip lobatto")
+            base_nodes, _ = self.g_c.gauss_lobatto(sample_points, 20)
+            sample_alphas = [float(b_n) for b_n in base_nodes]
+        elif interpolation == 'legendre':
+            # print("Ip legendre")
+            base_nodes, _ = self.g_c.gauss_legendre(sample_points, 20)
+            sample_alphas = [float(b_n) for b_n in base_nodes]
+        elif interpolation == 'chebychev':
+            # print("Ip chebychev")
+            base_nodes, _ = roots_chebyt(sample_points)
+            sample_alphas = base_nodes
+        return sample_alphas


### PR DESCRIPTION
Contains the whole P-CI-REXI library. 

The creation of EL-REXI(already part of sweet) coefficients is added to rexi_benchmarks.py.
The creation of Bean-REXI (using P-CI-REXI) and LR-REXI(using  P-CI-REXI) coefficients are added to rexi_benchmarks.py

Bean-REXI is based on a contour that is similar to an ellipse, but compressed, to avoid exp(SOME_LARGE_REAL_NUMBER)

LR-REXI is based on a rectangle contour. For each line Gauss-Legendre quadrature is used.

Calling rexi_benchmarks.py will result in the creation of 'gauss.cache.pkl'. This file contains cached Gauss-Legendre and Gauss-Lobatto nodes and weights, in addition to coefficients needed for spline interpolation.